### PR TITLE
fix(action): revert ssh-agent action version

### DIFF
--- a/.github/workflows/cicd-prod.yml
+++ b/.github/workflows/cicd-prod.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   deploy:
+    runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/')
 
     steps:
@@ -14,7 +15,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Setup SSH Agent
-      uses: webfactory/ssh-agent@v0.8.0
+      uses: webfactory/ssh-agent@v0.7.0
       with:
         ssh-private-key: ${{ secrets.SSH_PRODUCTION_PRIVATE_KEY }}
 


### PR DESCRIPTION
Testing reversion to `ssh-agent@0.7.0` as suggested in issues, plugging back the image runner otherwise syntax error